### PR TITLE
Release/0.1.7 pre alpha

### DIFF
--- a/17-camelforth-b.d/pico-examples/build/run_cmake_feather.sh
+++ b/17-camelforth-b.d/pico-examples/build/run_cmake_feather.sh
@@ -7,7 +7,8 @@
 
 # example only - may be applied to any board.
 
-cmake .. -D"PICO_BOARD=adafruit_feather_rp2040" -D"BOOT2_GENERIC_CF_LOCAL=1"
+# cmake .. -D"PICO_BOARD=adafruit_feather_rp2040" -D"BOOT2_GENERIC_CF_LOCAL=1"
+cmake .. -D"PICO_BOARD=adafruit_feather_rp2040"
 
 exit 0 # do not continue.  Exits this script on all pathways through it.
 

--- a/17-camelforth-b.d/pico-examples/build/run_cmake_itsyrp2040.sh
+++ b/17-camelforth-b.d/pico-examples/build/run_cmake_itsyrp2040.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+# cd pico-examples/build # just to establish where this is
+
+# cmake .. -D"PICO_BOARD=adafruit_itsybitsy_rp2040" -D"BOOT2_GENERIC_CF_LOCAL=1"
+cmake .. -D"PICO_BOARD=adafruit_itsybitsy_rp2040"
+
+exit 0 # do not continue.  Exits this script on all pathways through it.
+
+# the 'exit 0' protects this code from being executed:
+
+# standard build: RPi Pico 2040 target board:
+cmake .. -D"PICO_BOARD=pico"
+
+# Adafruit Feather RP2040, March 2021:
+cmake .. -D"PICO_BOARD=adafruit_feather_rp2040" -D"BOOT2_GENERIC_CF_LOCAL=1"
+
+# ls ../../pico-sdk/src/boards/include/boards/adafruit_feather_rp2040.h
+
+# Raspberry Pi Pico RP2040 is just 'pico' here:
+cmake -D"PICO_BOARD=pico" .. >> ./build.log 2>&1 ; date
+
+# documentation follows - from Appendix D of the SDK doco
+
+cat << _EOF
+
+
+Building applications with a custom board configuration
+
+The CMake system is what specifies which board configuration
+is going to be used.
+
+To create a new build based on a new board configuration
+(we will use the myboard example from the previous section)
+first create a new build folder under your project folder.
+
+For our example we will use the pico-examples folder.
+
+ $ cd pico-examples
+ $ mkdir myboard_build
+ $ cd myboard_build
+
+then run cmake as follows:
+
+ $ cmake -D"PICO_BOARD=myboard" .. # include the dot-dot path specifier
+
+This will set up the system ready to build so you can simply
+type 'make' in the myboard_build folder and the examples will
+be built for your new board configuration.
+_EOF
+
+#END.

--- a/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
@@ -1,8 +1,9 @@
 // forth.c
-#define RECENT_STAMP      "Sat Mar 27 06:10:31 UTC 2021"
-#define COMMIT_TIME_STAMP "Sat Mar 27 06:06:38 UTC 2021"
+#define RECENT_STAMP      "Wed Apr 14 12:16:49 UTC 2021"
+#define COMMIT_TIME_STAMP "Sat Mar 27 06:36:27 UTC 2021"
 #define BRANCH_STAMP      "dvlp-boot2-TESTING-blink-wait   0.1.5-pre-alpha"
-#define COMMIT_STAMP      "e1807a1" // seven characters
+#define BRANCH_STAMP      "dvlp-aa-all-a-                  0.1.5-pre-alpha"
+#define COMMIT_STAMP      "1e7ef4d" // seven characters
 #define FEATURE_STAMP     "+blinkwait +feather +no_emit         "
 
 // towards addressible flash block writes

--- a/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
@@ -1,10 +1,11 @@
 // forth.c
-#define RECENT_STAMP      "Wed Apr 14 12:16:49 UTC 2021"
-#define COMMIT_TIME_STAMP "Sat Mar 27 06:36:27 UTC 2021"
-#define BRANCH_STAMP      "dvlp-boot2-TESTING-blink-wait   0.1.5-pre-alpha"
+
+#include "pico-hardware-camelforth.h"
+#define RECENT_STAMP      "Wed Apr 14 13:36:55 UTC 2021"
+#define COMMIT_TIME_STAMP "Wed Apr 14 13:35:31 UTC 2021"
 #define BRANCH_STAMP      "dvlp-aa-all-a-                  0.1.5-pre-alpha"
-#define COMMIT_STAMP      "1e7ef4d" // seven characters
-#define FEATURE_STAMP     "+blinkwait +feather +no_emit         "
+#define COMMIT_STAMP      "387bad7" // seven characters
+#define FEATURE_STAMP     "+alltargets +blinkwait +feather      "
 
 // towards addressible flash block writes
 // still has rewind bug - may wish to call 'rewind' prior to 'COLD'
@@ -15,7 +16,7 @@
 // #define MODE_STAMP "no_flash   "
 // #define MODE_STAMP "no_flash   "
 #define VERS_CFORTH ("\103CamelForth in C v0.1 - 14 Feb 2016 - " COMMIT_TIME_STAMP "  ");
-#define DOFILLS_datus ("\n   " FEATURE_STAMP "    \n   branch " BRANCH_STAMP " " COMMIT_STAMP "\n   " MODE_STAMP " mode                  "  RECENT_STAMP "\n\n");
+#define DOFILLS_datus ("\n   " FEATURE_STAMP "  " CF_PICO_PLATFORM "\n   branch " BRANCH_STAMP " " COMMIT_STAMP "\n   " MODE_STAMP " mode                  "  RECENT_STAMP "\n\n");
 
 // special attempt: make some pointerish things more robust by
 // superstitiously using 'volatile' all over the place ;)

--- a/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
@@ -1,10 +1,10 @@
 // forth.c
 
 #include "pico-hardware-camelforth.h"
-#define RECENT_STAMP      "Wed Apr 14 13:36:55 UTC 2021"
-#define COMMIT_TIME_STAMP "Wed Apr 14 13:35:31 UTC 2021"
+#define RECENT_STAMP      "Wed Apr 14 14:00:29 UTC 2021"
+#define COMMIT_TIME_STAMP "Wed Apr 14 13:58:17 UTC 2021"
 #define BRANCH_STAMP      "dvlp-aa-all-a-                  0.1.5-pre-alpha"
-#define COMMIT_STAMP      "387bad7" // seven characters
+#define COMMIT_STAMP      "a2c9b66" // seven characters
 #define FEATURE_STAMP     "+alltargets +blinkwait +feather      "
 
 // towards addressible flash block writes

--- a/17-camelforth-b.d/pico-examples/camelforth-b/forth/pico-hardware-camelforth.h
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/forth/pico-hardware-camelforth.h
@@ -1,0 +1,34 @@
+// establish an ident string to print to console
+#include "pico/stdlib.h"
+#undef CF_PICO_PLATFORM
+
+#ifdef _BOARDS_PICO_H
+    #ifndef CF_PICO_PLATFORM
+        #define CF_PICO_PLATFORM "Raspberry Pi Pico RP2040 "
+    #endif
+#endif
+
+#ifdef ADAFRUIT_ITSYBITSY_RP2040
+    #ifndef CF_PICO_PLATFORM
+        #define CF_PICO_PLATFORM "Adafruit ItsyBitsy RP2040"
+    #endif
+#endif
+
+#ifdef ADAFRUIT_FEATHER_RP2040
+    #ifndef CF_PICO_PLATFORM
+        #define CF_PICO_PLATFORM "Adafruit Feather RP2040  "
+    #endif
+#endif
+
+#ifdef PIMORONI_TINY2040
+    #ifndef CF_PICO_PLATFORM
+        #define CF_PICO_PLATFORM "Pimoroni Tiny2040        "
+    #endif
+#endif
+
+#ifndef CF_PICO_PLATFORM
+    #warning -7777 // pico-hardware-camelforth.h
+    #warning -7778 // pico-hardware-camelforth.h
+    #define CF_PICO_PLATFORM "Generic RP2040 target    "
+    // -7777 // throw compile error
+#endif

--- a/17-camelforth-b.d/pico-examples/camelforth-b/forth/rp2040_pico_getkey_usb.inc
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/forth/rp2040_pico_getkey_usb.inc
@@ -5,7 +5,7 @@ uint8_t getKey(void) {     // hardware-independent wrapper
     uint8_t ch_read;
     int count=0;
     int flip, flop;
-    const uint LED_PIN = 25;
+    const uint LED_PIN = 25; // hard-coded for RPi Pico RP2040 only - needs update for multiple targets
     flip=-1;
     do {
         count++;

--- a/17-camelforth-b.d/pico-examples/camelforth-b/pico-hw/pico-LED/pico-LED.c
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/pico-hw/pico-LED/pico-LED.c
@@ -14,22 +14,25 @@ void _pico_LED_init(void) {
     gpio_set_dir(LED_PIN, GPIO_OUT);
 }
 
+/*
+void _sht_sleep(void) {
+    for (volatile int i = 4777; i>0; i--) { }
+}
+*/
+extern void _sht_sleep(void); // pico-LED.h
+
 int _pico_pip(void) {
-    const uint LED_PIN = LED_PIN_MASTER; // pico_LED.h
+    const uint LED_PIN = LED_PIN_MASTER;
     gpio_put(LED_PIN, 1);
-    sleep_ms(11);
+    _sht_sleep();
     gpio_put(LED_PIN, 0);
     sleep_ms(11);
 }
 
 int _pico_LED(void) {
-    const uint LED_PIN = LED_PIN_MASTER; // pico_LED.h
-    // gpio_init(LED_PIN);
-    // gpio_set_dir(LED_PIN, GPIO_OUT);
-    // while (true) {
-        gpio_put(LED_PIN, 1);
-        sleep_ms(250);
-        gpio_put(LED_PIN, 0);
-        sleep_ms(250);
-    // }
+    const uint LED_PIN = LED_PIN_MASTER;
+    gpio_put(LED_PIN, 1);
+    sleep_ms(2);
+    gpio_put(LED_PIN, 0);
+    sleep_ms(500);
 }

--- a/17-camelforth-b.d/pico-examples/camelforth-b/pico-hw/pico-LED/pico-LED.h
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/pico-hw/pico-LED/pico-LED.h
@@ -9,18 +9,30 @@
 #ifdef _BOARDS_PICO_H
     #ifndef LED_PIN_MASTER
         #define LED_PIN_MASTER 25;
+        #define PIP_LENGTH 4777 // untested
+    #endif
+#endif
+
+// itsybitsy
+// https://github.com/adafruit/circuitpython/blob/main/ports/raspberrypi/boards/adafruit_itsybitsy_rp2040/pins.c#L32
+#ifdef ADAFRUIT_ITSYBITSY_RP2040
+    #ifndef LED_PIN_MASTER
+        #define LED_PIN_MASTER 11;
+        #define PIP_LENGTH 4777 // probably okay
     #endif
 #endif
 
 #ifdef ADAFRUIT_FEATHER_RP2040
     #ifndef LED_PIN_MASTER
         #define LED_PIN_MASTER 13;
+        #define PIP_LENGTH 74777
     #endif
 #endif
 
 #ifdef PIMORONI_TINY2040
     #ifndef LED_PIN_MASTER
         #define LED_PIN_MASTER 13; // NO RESEARCH - validate me
+        #define PIP_LENGTH 74777 // untested - no target locally available to try this
     #endif
 #endif
 
@@ -28,5 +40,10 @@
     #warning -7777 // pico-LED.h  found no researched definition for the onboard LED pin
     #warning -7778 // pico-LED.h  LED_PIN_MASTER assigned to GPIO13, on a guess!
     #define LED_PIN_MASTER 13 // assumes 'standard' D13 assignment per Arduino IDE sensibilities
+    #define PIP_LENGTH 74777 // generic
     // -7777 // throw compile error
 #endif
+
+void _sht_sleep(void) {
+    for (volatile int i = PIP_LENGTH ; i>0; i--) { }
+}

--- a/README.md
+++ b/README.md
@@ -1,8 +1,30 @@
-# camelforth-rp2040-aU   UNSTABLE   0.1.4-pre-alpha   Tue Feb 16 15:34:07 UTC 2021
+# camelforth-rp2040-b-MS-U   UNSTABLE   0.1.6-pre-alpha   Wed Apr 14 14:10:42 UTC 2021
 
 CamelForth in C, by Dr. Brad Rodriguez
 
-UNSTABLE version
+UNSTABLE version - with mass storage support QSPI flashROM
+
+Stores forth source code in QSPI flash, and plays it
+back during COLD.
+
+'rewind' word controls what happens the next time COLD
+is called.  'rewind' allows the source to be read back
+into the interpreter; failure to use 'rewind' leaves
+the generic camelforth kernel, only, without the update
+to the forth dictionary provided by this mechanism.
+
+# NEWS
+
+14 April 2021 - three targets supported.
+
+RPi Pico RP2040, Adafruit Feather and ItsyBitsy RP2040
+(three targets) all supported.
+
+Use a different shell script to build each.
+
+see pico-examples/build for those scripts.
+
+# OLDER
 
  new feature: no-error getKey()
 

--- a/n.READY.FOR.RELEASE
+++ b/n.READY.FOR.RELEASE
@@ -1,7 +1,7 @@
-0.1.6-pre-alpha READY.FOR.RELEASE
+0.1.7-pre-alpha READY.FOR.RELEASE
 
-last commit 6a9b90ddd5b9dff6bc968e04b61e46bc860e34ee
+last commit 035231693bbc503c6a235d592b7977dfb4247a05
 
-Date:   Sat Mar 27 06:15:36 UTC 2021
+Date:   Wed Apr 14 14:37:37 UTC 2021
 
-    Blink on Wait - final edit
+    Terse notes to tell of new changes.


### PR DESCRIPTION
Updates to new pico-sdk method for choosing the driver for QSPI flashROM.

Handles three target boards: Adafruit Feather, ItsyBitsy RP2040 boards, as
well as the Raspberry Pi Pico RP2040 (the first port made of these three).

Shortens some of the blink times and provides per-target variance of those times.

GPIO25 blinks awaiting new keystrokes only on RPi Pico RP2040 (they
all do it, but only that board has the hardware to visualize it - an LED there).

Compiled against the 'master' branch of pico-sdk.