### PR TITLE
Release/0.1.9 pre alpha

### DIFF
--- a/17-camelforth-b.d/pico-examples/build/dothis_rp2040_pico.sh
+++ b/17-camelforth-b.d/pico-examples/build/dothis_rp2040_pico.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+
+export PICO_SDK_PATH=../../pico-sdk
+
+# change this line to point to the dev toolchain:
+export SOME_BIN_DIR=$HOME/this/dir/bin
+
+# example (assembler binary in the dev toolchain):
+# '$HOME/this/dir/bin/arm-none-eabi-as'
+
+cmake .. -D"PICO_BOARD=pico" -D"PICO_TOOLCHAIN_PATH=$SOME_BIN_DIR"
+
+exit 0
+
+# this script was added 30 March 2023 and is temporary.
+
+# It's an edit of a more stable script that's been in this
+# repository for a while.
+
+#END.

--- a/17-camelforth-b.d/pico-examples/build/example_config.log
+++ b/17-camelforth-b.d/pico-examples/build/example_config.log
@@ -1,0 +1,15 @@
+Wed  4 May 14:45:35 UTC 2022
+
+ $  diff run_cmake_pico.sh  working_copy_run_cmake_pico.sh
+11c11
+< export SOME_BIN_DIR=$PRIVATE
+---
+> export SOME_BIN_DIR=$HOME/this/dir/bin
+13,14c13,14
+< # cmake .. -D"PICO_BOARD=pico" -D"PICO_TOOLCHAIN_PATH=$SOME_BIN_DIR"
+< cmake .. -D"PICO_BOARD=pico"
+---
+> cmake .. -D"PICO_BOARD=pico" -D"PICO_TOOLCHAIN_PATH=$SOME_BIN_DIR"
+> # cmake .. -D"PICO_BOARD=pico"
+
+END.

--- a/17-camelforth-b.d/pico-examples/build/run_cmake_pico.sh
+++ b/17-camelforth-b.d/pico-examples/build/run_cmake_pico.sh
@@ -7,9 +7,22 @@
 
 # example only - may be applied to any board.
 
+export PICO_SDK_PATH=../../pico-sdk
+export SOME_BIN_DIR=$PRIVATE
+
+# cmake .. -D"PICO_BOARD=pico" -D"PICO_TOOLCHAIN_PATH=$SOME_BIN_DIR"
 cmake .. -D"PICO_BOARD=pico"
 
 exit 0 # do not continue.  Exits this script on all pathways through it.
+
+# #############  REAL PATHS  ###################
+#
+#   diff for real paths 04 May 2022:
+#   < export SOME_BIN_DIR=$PRIVATE
+#   ---
+#   > export SOME_BIN_DIR=$HOME/this/dir/bin
+#
+# ##############################################
 
 # the 'exit 0' protects this code from being executed:
 

--- a/17-camelforth-b.d/pico-examples/camelforth-b/CMakeLists.txt
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/CMakeLists.txt
@@ -6,17 +6,16 @@ add_executable(camelforth-b
 
 target_compile_definitions(camelforth-b PRIVATE
     # enable this flag only for no_flash compile:
-    # NO_FLASH_CMAKE=-1
+    NO_FLASH_CMAKE=-1
     # NO_FLASH_CMAKE=-1
 )
 
-# 11 May 00:40z trying PRIVATE on line below first time ever
-target_link_libraries(camelforth-b PRIVATE forth pico-LED ws2812 hardware_flash pico_stdlib)
+target_link_libraries(camelforth-b PRIVATE forth pico-LED asmword ws2812 hardware_flash pico_stdlib)
 
 # pico_set_binary_type(camelforth-b copy_to_ram)
-pico_set_binary_type(camelforth-b copy_to_ram)
+# pico_set_binary_type(camelforth-b copy_to_ram)
 # pico_set_binary_type(camelforth-b no_flash)
-# pico_set_binary_type(camelforth-b no_flash)
+pico_set_binary_type(camelforth-b no_flash)
 
 pico_enable_stdio_usb(camelforth-b 1)
 pico_enable_stdio_uart(camelforth-b 1) # was zero
@@ -32,3 +31,4 @@ endif()
 add_subdirectory(forth)
 add_subdirectory(pico-hw)
 add_subdirectory(pio)
+add_subdirectory(asm)

--- a/17-camelforth-b.d/pico-examples/camelforth-b/NOTE.md
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/NOTE.md
@@ -1,0 +1,17 @@
+Fri 31 Mar 18:16:07 UTC 2023
+
+  Please see:
+
+    git.show.2b0c845.log
+
+Revert the flags if you wanted persistence - program is
+configured (in this file) to compile to a no flashROM
+image.
+
+That way, another build of the same program can be resident
+in flashROM, whereas the unstable work done recently is
+uploaded via .UF2 - but does not get written to the storage
+holding the (more stable) version that's resident in flashROM.
+
+The commit is shown (in full) in the above cited logfile :)
+

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/CMakeLists.txt
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/CMakeLists.txt
@@ -1,0 +1,7 @@
+if ( CMAKE_COMPILER_IS_GNUCC )
+    set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wall -Wextra")
+endif()
+
+# include_directories(../../include)
+add_library(asmword asmword.c asmword.S)
+target_link_libraries(asmword pico_stdlib)

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/README.md
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/README.md
@@ -3,4 +3,10 @@
 
   https://wokwi.com/projects/360654241673775105
 
+  asmword   - blinks 16 times (maybe - not tested well)
+
+  It returns to the text interpreter as usual.
+
+  WORKING PROGRAM  Fri 31 Mar 00:10 UTC 2023
+
 #### End.

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/README.md
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/README.md
@@ -1,0 +1,6 @@
+# Assembler in pico-sdk
+## Thu 30 Mar 23:26:43 UTC 2023
+
+  https://wokwi.com/projects/360654241673775105
+
+#### End.

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/asmword.S
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/asmword.S
@@ -1,0 +1,227 @@
+@ asmword.S
+
+@ was: cloop.S
+
+@ Thu 30 Mar 21:31:32 UTC 2023
+
+@ https://wokwi.com/projects/360645588605043713
+
+@ - - - - -   architecture flags   - - - - -
+
+.syntax unified
+.cpu    cortex-m0plus
+.thumb
+
+.global experiment_a_asm
+.align 4
+
+
+@ - - - - -   pico-sdk constants   - - - - -
+
+.equ IO_BANK0_BASE       , 0x40014000
+.equ GPIO_09_CTRL        , IO_BANK0_BASE + 8 *  9 + 4
+.equ GPIO_25_CTRL        , IO_BANK0_BASE + 8 * 25 + 4
+
+.equ SIO_BASE            , 0xd0000000
+.equ GPIO_OE_SET         , 0x024 @ GPIO output enable set
+.equ GPIO_OUT_SET        , 0x014 @ GPIO output value set
+.equ GPIO_OUT_CLR        , 0x018 @ GPIO output value clear
+.equ GPIO_OUT_XOR        , 0x01c @ GPIO output value XOR
+
+@ - - - - -   program constants   - - - - -
+
+@  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+@  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+@  -  -  -  -  -  -     configure me   -  -  -  -  -  -  -  -
+
+        .equ toggle_flash_vs_buzz, 1 @ or 0 to buzz
+
+@  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+@  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+@  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -
+
+
+.equ LED_PIN             , 25 @ builtin
+.equ LED_ALT_PIN         ,  9
+
+.equ ITERATIONS          ,  8 @ default to buzzer
+.equ TRIMMED_ITER        ,  3
+
+.equ TONE_COEFFIC        , 0x40 @ 0x02 0x04 0x08.. only
+
+#include "config.S"
+
+gpio09_lit:
+   push  {lr}
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_ALT_PIN @ 9
+   str    r0, [r1, #GPIO_OUT_SET]
+   pop   {pc}
+
+gpio09_dark:
+   push  {lr}
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_ALT_PIN @ 9
+   str    r0, [r1, #GPIO_OUT_CLR]
+   pop   {pc}
+
+many_nops:
+   push  {lr}
+   movs   r2, #1
+   movs   r3, #1
+1: push  {r2}
+   push  {r3}
+   nop   @ payload
+   pop   {r3}
+   pop   {r2}
+   add    r3, r2
+   cmp    r3, #TONE_COEFFIC @ iterations
+   bne    1b
+   pop   {pc}
+
+payload_a:
+   push  {lr}
+   push  {r2}
+   push  {r3}
+   bl many_nops
+   pop   {r3}
+   pop   {r2}
+   pop   {pc}
+
+counted_b:
+   push  {lr}
+   movs  r2, #1
+   movs  r3, #1
+1: push  {r2}
+   push  {r3}
+   bl    payload_a
+   pop   {r3}
+   pop   {r2}
+   add    r3, r2
+   cmp    r3, #ITERATIONS
+   bne    1b
+   pop   {pc}
+
+counted_a:
+   push  {lr}
+   movs   r2, #1
+   movs   r3, #1
+1: push  {r2}
+   push  {r3}
+   bl    counted_b
+   pop   {r3}
+   pop   {r2}
+   add    r3, r2
+   cmp    r3, #ITERATIONS
+   bne    1b
+   pop   {pc}
+
+counted:
+   push  {lr}
+   movs   r2, #1
+   movs   r3, #1
+1: push  {r2}
+   push  {r3}
+   bl    counted_a
+   pop   {r3}
+   pop   {r2}
+   add    r3, r2
+   cmp    r3, #ITERATIONS
+   bne    1b
+   pop   {pc}
+
+led_delayed:
+   push  {lr}
+   bl counted
+   pop   {pc}
+
+toggle_gpio09:
+   push  {lr}
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_ALT_PIN
+   str    r0, [r1, #GPIO_OUT_XOR]
+   pop   {pc}
+
+toggle_gpio25:
+   push  {lr}
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_PIN
+   str    r0, [r1, #GPIO_OUT_XOR]
+   pop   {pc}
+
+blinking:
+   push  {lr}
+   bl    toggle_gpio25
+   bl    toggle_gpio25
+   bl    led_delayed
+   bl    toggle_gpio09
+   bl    led_delayed
+   pop   {pc}
+
+gpio25_lit:
+   push  {lr}
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_PIN @ 25
+   str    r0, [r1, #GPIO_OUT_SET]
+   pop   {pc}
+
+gpio25_dark:
+   push  {lr}
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_PIN @ 25
+   str    r0, [r1, #GPIO_OUT_CLR]
+   pop   {pc}
+
+setup_gpio09:
+   push  {lr}
+   // Set GPIO[09] function to single-cyle I/O
+   ldr    r1, =GPIO_09_CTRL
+   movs   r0, #5
+   str    r0, [r1]
+   // Set GPIO[09] output enable
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_ALT_PIN @ 9
+   str    r0, [r1, #GPIO_OE_SET]
+   pop   {pc}
+
+setup_gpio25:
+   push  {lr}
+   // Set GPIO[25] function to single-cyle I/O
+   ldr    r1, =GPIO_25_CTRL
+   movs   r0, #5
+   str    r0, [r1]
+   // Set GPIO[25] output enable
+   ldr    r1, =SIO_BASE
+   ldr    r0, =1<<LED_PIN @ 25
+   str    r0, [r1, #GPIO_OE_SET]
+   pop   {pc}
+
+gpio_setup:
+   push  {lr}
+   bl    setup_gpio25
+   bl    setup_gpio09
+   pop   {pc}
+
+program_setup:
+   push  {lr}
+   bl    gpio_setup
+   pop   {pc}
+
+traploop:
+1: bl    blinking
+   bne   1b
+
+@  --------------------   main   ------------------    
+
+experiment_a_asm:
+   bl    program_setup
+   bl    gpio09_lit
+   bl    toggle_gpio25
+   b     traploop
+
+@ Set data alignment
+.data
+    .align 4
+
+@ end.
+

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/asmword.S
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/asmword.S
@@ -151,11 +151,15 @@ toggle_gpio25:
 
 blinking:
    push  {lr}
+   push  {r2}
+   push  {r3}
    bl    toggle_gpio25
-   bl    toggle_gpio25
+   @ bl    toggle_gpio25
    bl    led_delayed
    bl    toggle_gpio09
    bl    led_delayed
+   pop   {r3}
+   pop   {r2}
    pop   {pc}
 
 gpio25_lit:
@@ -211,13 +215,36 @@ traploop:
 1: bl    blinking
    bne   1b
 
+.equ LOOPING, 32
+
+runasm:
+   push  {lr}
+   movs  r2, #1
+   movs  r3, #1
+1: push  {r2}
+   push  {r3}
+   bl    blinking
+   pop   {r3}
+   pop   {r2}
+   add    r3, r2
+   cmp    r3, #LOOPING
+   bne    1b
+   pop   {pc}
+
 @  --------------------   main   ------------------    
 
 experiment_a_asm:
+   push  {lr}
    bl    program_setup
    bl    gpio09_lit
    bl    toggle_gpio25
-   b     traploop
+   bl    runasm
+   pop   {pc}
+
+   @ don't know how to terminate
+   @ pop   {pc}
+
+   @ b     traploop
 
 @ Set data alignment
 .data

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/asmword.c
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/asmword.c
@@ -1,0 +1,23 @@
+// cloop.c
+
+// Thu 30 Mar 21:32:55 UTC 2023
+
+// @ https://wokwi.com/projects/360645588605043713
+
+#include "hardware/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void experiment_a_asm();
+
+#ifdef __cplusplus
+}
+#endif
+
+void asmword(void) {
+	return experiment_a_asm();
+}
+
+// END.

--- a/17-camelforth-b.d/pico-examples/camelforth-b/asm/config.S
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/asm/config.S
@@ -1,0 +1,29 @@
+@ Thu 30 Mar 22:11:51 UTC 2023
+
+@ config.S
+
+@ https://wokwi.com/projects/360645588605043713
+
+@ not the user interface:
+.if (toggle_flash_vs_buzz == 1)
+.equ it_buzzes, 0
+.equ it_flashes, 1
+.endif
+
+.if (toggle_flash_vs_buzz == 0)
+.equ it_buzzes, 1
+.equ it_flashes, 0
+.endif
+
+.if (it_buzzes == 1)
+  .equ ITERATIONS          ,  8
+  .equ TRIMMED_ITER        ,  4
+.endif
+
+.if (it_flashes == 1)
+  .equ ITERATIONS          ,  32
+  .equ TRIMMED_ITER        ,  8
+.endif
+
+@ end.
+

--- a/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/forth/forth.c
@@ -717,6 +717,11 @@ CODE(rewind) { // reset flash loader to the base of that sector
     getFlKey_counter = 0;
 }
 
+extern void asmword(void);
+CODE(asmword) { /* -- */
+    asmword();
+}
+
 CODE(bye) {
     run = 0;
 }
@@ -825,6 +830,7 @@ PRIMITIVE(buf2flash);
 PRIMITIVE(rewind);
 PRIMITIVE(erase);
 PRIMITIVE(reading);
+PRIMITIVE(asmword);
 PRIMITIVE(bye);
 
 /* USER VARIABLES */
@@ -1710,4 +1716,5 @@ HEADER(rewind, reading, 0, "\006rewind");
 HEADER(flkey, rewind, 0, "\005flkey");
 HEADER(flaccept, flkey, 0, "\010flaccept");
 HEADER(flquit, flaccept, 0, "\006flquit");
-HEADER(cold, flquit, 0, "\004COLD");
+HEADER(asmword, flquit, 0, "\007asmword");
+HEADER(cold, asmword, 0, "\004COLD");

--- a/17-camelforth-b.d/pico-examples/camelforth-b/git.show.2b0c845.log
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/git.show.2b0c845.log
@@ -1,0 +1,37 @@
+commit 2b0c84569221c28a74c846c898f01a483245775d
+Author: wa1tnr <wa1tnr@users.noreply.github.com>
+Date:   Thu Mar 30 22:44:25 2023 +0000
+
+    ASM first commit long time
+
+diff --git a/17-camelforth-b.d/pico-examples/camelforth-b/CMakeLists.txt b/17-camelforth-b.d/pico-examples/camelforth-b/CMakeLists.txt
+index 6b82fda..f9d312b 100644
+--- a/17-camelforth-b.d/pico-examples/camelforth-b/CMakeLists.txt
++++ b/17-camelforth-b.d/pico-examples/camelforth-b/CMakeLists.txt
+@@ -6,17 +6,16 @@ add_executable(camelforth-b
+ 
+ target_compile_definitions(camelforth-b PRIVATE
+     # enable this flag only for no_flash compile:
+-    # NO_FLASH_CMAKE=-1
++    NO_FLASH_CMAKE=-1
+     # NO_FLASH_CMAKE=-1
+ )
+ 
+-# 11 May 00:40z trying PRIVATE on line below first time ever
+-target_link_libraries(camelforth-b PRIVATE forth pico-LED ws2812 hardware_flash pico_stdlib)
++target_link_libraries(camelforth-b PRIVATE forth pico-LED asmword ws2812 hardware_flash pico_stdlib)
+ 
+ # pico_set_binary_type(camelforth-b copy_to_ram)
+-pico_set_binary_type(camelforth-b copy_to_ram)
+-# pico_set_binary_type(camelforth-b no_flash)
++# pico_set_binary_type(camelforth-b copy_to_ram)
+ # pico_set_binary_type(camelforth-b no_flash)
++pico_set_binary_type(camelforth-b no_flash)
+ 
+ pico_enable_stdio_usb(camelforth-b 1)
+ pico_enable_stdio_uart(camelforth-b 1) # was zero
+@@ -32,3 +31,4 @@ endif()
+ add_subdirectory(forth)
+ add_subdirectory(pico-hw)
+ add_subdirectory(pio)
++add_subdirectory(asm)

--- a/17-camelforth-b.d/pico-examples/camelforth-b/include/forth_defines.h
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/include/forth_defines.h
@@ -1,7 +1,8 @@
-#warning seen 30 Mar 2023 forth_defines.h
+// #warning seen 30 Mar 2023 forth_defines.h
 
-#define RECENT_STAMP      "Thu 30 Mar 22:22:12 UTC 2023"
-#define COMMIT_TIME_STAMP "Mon Nov 14 17:49:55 UTC 2022"
-#define BRANCH_STAMP      "dvlp-aa                         0.1.8-pre-alpha"
-#define COMMIT_STAMP      "adf3333" // seven characters
-#define FEATURE_STAMP     "+ASM BOX 30 Mar +no_flash +clkdiv_ha "
+#define RECENT_STAMP      "Thu 30 Mar 22:51:41 UTC 2023"
+#define COMMIT_TIME_STAMP "Thu Mar 30 22:46:07 UTC 2023"
+#define BRANCH_STAMP      "dvlp-asm-aa                     0.1.8-pre-alpha"
+#define COMMIT_STAMP      "14e421d" // seven characters
+#define FEATURE_STAMP     "+ASM BOX +github +no_flash +clkdiv_h "
+

--- a/17-camelforth-b.d/pico-examples/camelforth-b/include/forth_defines.h
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/include/forth_defines.h
@@ -1,8 +1,8 @@
 // #warning seen 30 Mar 2023 forth_defines.h
 
-#define RECENT_STAMP      "Thu 30 Mar 22:51:41 UTC 2023"
-#define COMMIT_TIME_STAMP "Thu Mar 30 22:46:07 UTC 2023"
-#define BRANCH_STAMP      "dvlp-asm-aa                     0.1.8-pre-alpha"
-#define COMMIT_STAMP      "14e421d" // seven characters
+// RECENT_STAMP is for after a commit when there is a change
+#define RECENT_STAMP      "Fri Mar 31 00:10:34 UTC 2023"
+#define COMMIT_TIME_STAMP "Fri Mar 31 00:10:34 UTC 2023"
+#define BRANCH_STAMP      "dvlp-asm-aa   later alligator   0.1.8-pre-alpha"
+#define COMMIT_STAMP      "b70b8b7" // seven characters
 #define FEATURE_STAMP     "+ASM BOX +github +no_flash +clkdiv_h "
-

--- a/17-camelforth-b.d/pico-examples/camelforth-b/include/forth_defines.h
+++ b/17-camelforth-b.d/pico-examples/camelforth-b/include/forth_defines.h
@@ -1,8 +1,7 @@
+#warning seen 30 Mar 2023 forth_defines.h
 
-// #warning seen forth_defines.h
-
-#define RECENT_STAMP      "Wed Oct 27 12:50:11 UTC 2021"
-#define COMMIT_TIME_STAMP "Wed May 12 21:18:08 UTC 2021"
+#define RECENT_STAMP      "Thu 30 Mar 22:22:12 UTC 2023"
+#define COMMIT_TIME_STAMP "Mon Nov 14 17:49:55 UTC 2022"
 #define BRANCH_STAMP      "dvlp-aa                         0.1.8-pre-alpha"
-#define COMMIT_STAMP      "1f700c1" // seven characters
-#define FEATURE_STAMP     "+clkdiv_hack +neopix +headers        "
+#define COMMIT_STAMP      "adf3333" // seven characters
+#define FEATURE_STAMP     "+ASM BOX 30 Mar +no_flash +clkdiv_ha "

--- a/README.md
+++ b/README.md
@@ -11,8 +11,36 @@ Stores forth source code in QSPI flash, and plays it
 back during COLD (player piano).
 
 # NEWS
+## 4 November 2022 - inquiry received
 
-14 April 2021 - three targets supported.
+
+> Begin forwarded message:
+
+> Date: Mon, 14 Nov 2022 15:03:24 +0000
+> From: D.V.
+> Subject: [CamelForth] Camelforth for Pico
+
+> Wondering whether the implementor will continue to develop the Pico implementation and/or 'entertain' questions about the implementation.
+
+> I didn't see any contact information on this site or the 'github' material.  Thank you!
+
+The one open issue already invites contact through the issue mechanism.
+
+Work is only done on this repository when a specific operational
+difficulty arises, such as an update to pico-sdk that changes
+how (or if) the program continues to compile correctly.
+
+Not noticed ordinarily, as the project is essentially mothballed.
+
+In its current state it should be able to read and write to
+on-board (external, QSPI) flashROM 'raw'.  This amounts to a
+player piano situation; it plays back the Forth source code
+(in ascii representation, as with any ascii plaintext file)
+.. upon a cold boot.
+
+Which, in turn, amounts to an extended Forth dictionary.
+
+## 14 April 2021 - three targets supported.
 
 RPi Pico RP2040, Adafruit Feather and ItsyBitsy RP2040
 (three targets) all supported.

--- a/README.md
+++ b/README.md
@@ -16,15 +16,17 @@ back during COLD (player piano).
 
 > Begin forwarded message:
 
-> Date: Mon, 14 Nov 2022 15:03:24 +0000
-> From: D.V.
-> Subject: [CamelForth] Camelforth for Pico
+&gt; Date: Mon, 14 Nov 2022 15:03:24 +0000 
 
-> Wondering whether the implementor will continue to develop the Pico implementation and/or 'entertain' questions about the implementation.
+&gt; From: D.V. 
 
-> I didn't see any contact information on this site or the 'github' material.  Thank you!
+&gt; Subject: [CamelForth] Camelforth for Pico 
 
-The one open issue already invites contact through the issue mechanism.
+>&gt; Wondering whether the implementor will continue to develop the Pico implementation and/or 'entertain' questions about the implementation.
+
+>&gt; I didn't see any contact information on this site or the 'github' material.  Thank you!
+
+The one open [issue](https://github.com/wa1tnr/camelforth-rp2040-b-MS-U/issues/2) already invites contact through the issue mechanism.
 
 Work is only done on this repository when a specific operational
 difficulty arises, such as an update to pico-sdk that changes

--- a/n.READY.FOR.RELEASE
+++ b/n.READY.FOR.RELEASE
@@ -1,7 +1,7 @@
-0.1.7-pre-alpha READY.FOR.RELEASE
+0.1.9-pre-alpha READY.FOR.RELEASE
 
-last commit 035231693bbc503c6a235d592b7977dfb4247a05
+last commit c6cc55e06e532433e1bcd74ba65d4d0ae6003ce2
 
-Date:   Wed Apr 14 14:37:37 UTC 2021
+Date:   Fri Mar 31 00:14:52 UTC 2023
 
-    Terse notes to tell of new changes.
+    blind commit


### PR DESCRIPTION
This'll be fine - saw proposed release (no. 6) just now.  Looks good.

Changes: CMakeLists.txt (one instance only) reconfigured for

`pico_set_binary_type(camelforth-b no_flash)`

whereas it was formerly set to

`pico_set_binary_type(camelforth-b copy_to_ram)`

per commit 2b0c845

 16 +    NO_FLASH_CMAKE=-1
 21 -target_link_libraries(camelforth-b PRIVATE forth pico-LED ws2812 hardware_flash pico_stdlib)
 22 +target_link_libraries(camelforth-b PRIVATE forth pico-LED asmword ws2812 hardware_flash pico_stdlib)
 25 -pico_set_binary_type(camelforth-b copy_to_ram)
 26 -# pico_set_binary_type(camelforth-b no_flash)
 27 +# pico_set_binary_type(camelforth-b copy_to_ram)
 28  # pico_set_binary_type(camelforth-b no_flash)
 29 +pico_set_binary_type(camelforth-b no_flash)
 37 +add_subdirectory(asm)
